### PR TITLE
Airspace logging to file and other improvements

### DIFF
--- a/ATC/src/ATC.cpp
+++ b/ATC/src/ATC.cpp
@@ -164,7 +164,7 @@ void computerSystemDemo() {
 		std::cout << "ComputerSystem: failed to attach to. Exiting thread.";
 		return;
 	}
-	std::this_thread::sleep_for(std::chrono::milliseconds(15 * 1000));
+	std::this_thread::sleep_for(std::chrono::milliseconds(25 * 1000));
 
 	ComputerSystemMessage msg;
 	msg.command = COMMAND_EXIT_THREAD;

--- a/ATC/src/ATC.cpp
+++ b/ATC/src/ATC.cpp
@@ -148,7 +148,7 @@ void computerSystemDemo() {
 
 	pthread_create(&opConsoleTid, NULL, &OperatorConsole::start, &opConsole);
 	pthread_create(&displayTid, NULL, &DataDisplay::start, &display);
-	while (opConsole.getChid() == -1 && displayTid == -1)
+	while (opConsole.getChid() == -1 || display.getChid() == -1)
 		;
 
 	compSystem.setDisplayChid(display.getChid());

--- a/ATC/src/ATC.cpp
+++ b/ATC/src/ATC.cpp
@@ -164,7 +164,7 @@ void computerSystemDemo() {
 		std::cout << "ComputerSystem: failed to attach to. Exiting thread.";
 		return;
 	}
-	std::this_thread::sleep_for(std::chrono::milliseconds(25 * 1000));
+	std::this_thread::sleep_for(std::chrono::milliseconds(15 * 1000));
 
 	ComputerSystemMessage msg;
 	msg.command = COMMAND_EXIT_THREAD;
@@ -173,11 +173,32 @@ void computerSystemDemo() {
 	} else {
 		cout << "Unable to shut down compSystem." << endl;
 	}
+	ConnectDetach(compSystemCoid);
+	pthread_join(compSystemTid, NULL);
+
+	dataDisplayCommandMessage ddMsg;
+	ddMsg.commandType = COMMAND_EXIT_THREAD;
+	int ddCoid = ConnectAttach(0, 0, display.getChid(), _NTO_SIDE_CHANNEL, 0);
+	MsgSend(ddCoid, &ddMsg, sizeof(ddMsg), NULL, 0);
+	ConnectDetach(ddCoid);
+	pthread_join(displayTid, NULL);
+
+	OperatorConsoleCommandMessage ocMsg;
+	ocMsg.systemCommandType = COMMAND_EXIT_THREAD;
+	int ocCoid = ConnectAttach(0, 0, opConsole.getChid(), _NTO_SIDE_CHANNEL, 0);
+	MsgSend(ocCoid, &ocMsg, sizeof(ocMsg), NULL, 0);
+	ConnectDetach(ocCoid);
+	pthread_join(opConsoleTid, NULL);
 
 	for (size_t i = 0; i < planes.size(); i++) {
+		PlaneCommandMessage exitMsg;
+		exitMsg.command = COMMAND_EXIT_THREAD;
+		int planeCoid = ConnectAttach(0, 0, planes[i].getChid(), _NTO_SIDE_CHANNEL, 0);
+		MsgSend(planeCoid, &exitMsg, sizeof(exitMsg), NULL, 0);
+		ConnectDetach(planeCoid);
 		pthread_join(planeThreads[i], NULL);
 	}
-	pthread_join(compSystemTid, NULL);
+
 }
 
 int main() {

--- a/ATC/src/ATC.cpp
+++ b/ATC/src/ATC.cpp
@@ -193,7 +193,8 @@ void computerSystemDemo() {
 	for (size_t i = 0; i < planes.size(); i++) {
 		PlaneCommandMessage exitMsg;
 		exitMsg.command = COMMAND_EXIT_THREAD;
-		int planeCoid = ConnectAttach(0, 0, planes[i].getChid(), _NTO_SIDE_CHANNEL, 0);
+		int planeCoid = ConnectAttach(0, 0, planes[i].getChid(),
+				_NTO_SIDE_CHANNEL, 0);
 		MsgSend(planeCoid, &exitMsg, sizeof(exitMsg), NULL, 0);
 		ConnectDetach(planeCoid);
 		pthread_join(planeThreads[i], NULL);

--- a/ATC/src/ATC.cpp
+++ b/ATC/src/ATC.cpp
@@ -120,8 +120,8 @@ void OperatorConsoleDemo() {
 
 void computerSystemDemo() {
 	pthread_t compSystemTid, opConsoleTid, displayTid;
-	PlaneStartParams params1 = { 1, 1, { 0, 0, 0 }, { 1, 1, 0 } };
-	PlaneStartParams params2 = { 2, 1, { 0, 0, 0 }, { 1000, 1000, 0 } };
+	PlaneStartParams params1 = { 1, 1, { 0, 50000, 20000 }, { 1000, 0, 0 } };
+	PlaneStartParams params2 = { 2, 1, { 50000, 0, 20000 }, { 0, 1000, 0 } };
 	PlaneStartParams params3 = { 3, 3, { 3, 3, 3 }, { 3, 3, 3 } };
 	Plane plane1 = Plane(params1);
 	Plane plane2 = Plane(params2);
@@ -144,7 +144,7 @@ void computerSystemDemo() {
 
 	compSystem.setRadar(radar);
 	compSystem.setCommSystem(commSystem);
-	compSystem.setCongestionDegreeSeconds(5000);
+	compSystem.setCongestionDegreeSeconds(15);
 
 	pthread_create(&opConsoleTid, NULL, &OperatorConsole::start, &opConsole);
 	pthread_create(&displayTid, NULL, &DataDisplay::start, &display);
@@ -164,7 +164,7 @@ void computerSystemDemo() {
 		std::cout << "ComputerSystem: failed to attach to. Exiting thread.";
 		return;
 	}
-	std::this_thread::sleep_for(std::chrono::milliseconds(15 * 1000));
+	std::this_thread::sleep_for(std::chrono::milliseconds(60 * 1000));
 
 	ComputerSystemMessage msg;
 	msg.command = COMMAND_EXIT_THREAD;

--- a/ATC/src/CommunicationSystem.cpp
+++ b/ATC/src/CommunicationSystem.cpp
@@ -8,11 +8,10 @@
 #include "CommunicationSystem.h"
 #include "commandCodes.h"
 
-
-CommunicationSystem::CommunicationSystem(){
+CommunicationSystem::CommunicationSystem() {
 }
-CommunicationSystem::CommunicationSystem(std::vector<Plane> &planes)
-	: planes(planes) {
+CommunicationSystem::CommunicationSystem(std::vector<Plane> &planes) :
+		planes(planes) {
 
 }
 

--- a/ATC/src/CommunicationSystem.cpp
+++ b/ATC/src/CommunicationSystem.cpp
@@ -41,7 +41,7 @@ bool CommunicationSystem::send(Plane &R, Vec3 &newVelocity) {
 	msg.newVelocity = newVelocity; //setting the new velocity
 
 	sndid = MsgSend(coid, &msg, sizeof(msg), NULL, 0); //NULL & 0 since not expecting a reply
-
+	ConnectDetach(coid);
 	if (sndid == -1) {
 		std::cout << "Message failed to send!" << std::endl;
 		return false;

--- a/ATC/src/ComputerSystem.cpp
+++ b/ATC/src/ComputerSystem.cpp
@@ -148,6 +148,7 @@ void ComputerSystem::listen() {
 void ComputerSystem::logSystem(bool toFile) {
 	this->airspace = radar.pingAirspace();
 	size_t aircraftCount = airspace.size();
+
 	int *idArray = new int[aircraftCount];
 	Vec3 *positionArray = new Vec3[aircraftCount];
 	Vec3 *velocityArray = new Vec3[aircraftCount];
@@ -176,25 +177,9 @@ void ComputerSystem::logSystem(bool toFile) {
 		exit(-1);
 	}
 	ConnectDetach(coid);
-
-	/*ofstream logfile;
-	printCurrentTime();
-	for (auto const &x : airspace) {
-		logfile.open("logfile.txt");
-		logfile << x.first << ":" << std::to_string(x.second.currentPosition.x)
-				<< "," << std::to_string(x.second.currentPosition.y) << ","
-				<< std::to_string(x.second.currentPosition.z) << "|";
-		printf(" %d:%s,%s,%s |", x.first,
-				std::to_string(x.second.currentPosition.x),
-				std::to_string(x.second.currentPosition.y),
-				std::to_string(x.second.currentPosition.z));
-		if (x.first % 5 == 0 && x.first != 0) {
-			cout << endl;
-		}
-	}
-	cout << endl;
-	logfile << endl;
-	logfile.close();*/
+	delete[] idArray;
+	delete[] positionArray;
+	delete[] velocityArray;
 }
 
 void ComputerSystem::opConCheck() {

--- a/ATC/src/ComputerSystem.cpp
+++ b/ATC/src/ComputerSystem.cpp
@@ -269,9 +269,9 @@ void ComputerSystem::checkForFutureViolation(
 //	cout << "ComputerSystem: " << "Distance between plane " << plane1.first
 //			<< " and " << plane2.first << " is "
 //			<< distancesBetweenPlanes.print() << endl;
-	if (distancesBetweenPlanes.x <= HORIZONTAL_LIMIT
-			|| distancesBetweenPlanes.y <= HORIZONTAL_LIMIT
-			|| distancesBetweenPlanes.z <= VERTICAL_LIMIT) {
+	if ((distancesBetweenPlanes.x <= HORIZONTAL_LIMIT
+			|| distancesBetweenPlanes.y <= HORIZONTAL_LIMIT)
+			&& distancesBetweenPlanes.z <= VERTICAL_LIMIT) {
 		int coid = ConnectAttach(0, 0, operatorChid, _NTO_SIDE_CHANNEL, 0);
 		OperatorConsoleCommandMessage sendMsg;
 		sendMsg.plane1 = plane1.first;

--- a/ATC/src/ComputerSystem.cpp
+++ b/ATC/src/ComputerSystem.cpp
@@ -56,7 +56,7 @@ void ComputerSystem::createPeriodicTasks() {
 
 	periodicTask periodicTasks[COMPUTER_SYSTEM_NUM_PERIODIC_TASKS] = { {
 	AIRSPACE_VIOLATION_CONSTRAINT_TIMER, 1 }, { LOG_AIRSPACE_TO_CONSOLE_TIMER, 5 }, {
-	OPERATOR_COMMAND_CHECK_TIMER, 1 }, {LOG_AIRSPACE_TO_FILE_TIMER, 10} }; // TODO change file logging to 30 second period
+	OPERATOR_COMMAND_CHECK_TIMER, 1 }, {LOG_AIRSPACE_TO_FILE_TIMER, 30} };
 
 	// Create a new communication channel belonging to the plane and store the handle in chid.
 	if ((chid = ChannelCreate(0)) == -1) {

--- a/ATC/src/ComputerSystem.cpp
+++ b/ATC/src/ComputerSystem.cpp
@@ -55,8 +55,10 @@ void ComputerSystem::createPeriodicTasks() {
 	 */
 
 	periodicTask periodicTasks[COMPUTER_SYSTEM_NUM_PERIODIC_TASKS] = { {
-	AIRSPACE_VIOLATION_CONSTRAINT_TIMER, 1 }, { LOG_AIRSPACE_TO_CONSOLE_TIMER, 5 }, {
-	OPERATOR_COMMAND_CHECK_TIMER, 1 }, {LOG_AIRSPACE_TO_FILE_TIMER, 30} };
+	AIRSPACE_VIOLATION_CONSTRAINT_TIMER, 1 },
+			{ LOG_AIRSPACE_TO_CONSOLE_TIMER, 5 }, {
+			OPERATOR_COMMAND_CHECK_TIMER, 1 },
+			{ LOG_AIRSPACE_TO_FILE_TIMER, 30 } };
 
 	// Create a new communication channel belonging to the plane and store the handle in chid.
 	if ((chid = ChannelCreate(0)) == -1) {
@@ -153,7 +155,7 @@ void ComputerSystem::logSystem(bool toFile) {
 	Vec3 *positionArray = new Vec3[aircraftCount];
 	Vec3 *velocityArray = new Vec3[aircraftCount];
 	for (size_t i = 0; i < aircraftCount; i++) {
-		auto& current = airspace[i];
+		auto &current = airspace[i];
 		idArray[i] = current.first;
 		positionArray[i] = current.second.currentPosition;
 		velocityArray[i] = current.second.currentVelocity;
@@ -172,8 +174,7 @@ void ComputerSystem::logSystem(bool toFile) {
 
 	int coid = ConnectAttach(0, 0, displayChid, _NTO_SIDE_CHANNEL, 0);
 	if (MsgSend(coid, &msg, sizeof(msg), NULL, 0) == -1) {
-		cout << "ComputerSystem: "
-				<< "Couldn't send command to the display.";
+		cout << "ComputerSystem: " << "Couldn't send command to the display.";
 		exit(-1);
 	}
 	ConnectDetach(coid);

--- a/ATC/src/ComputerSystem.cpp
+++ b/ATC/src/ComputerSystem.cpp
@@ -193,6 +193,7 @@ void ComputerSystem::opConCheck() {
 				<< "Couldn't get user request queue from operator console";
 		exit(-1);
 	}
+	ConnectDetach(coid);
 	switch (rcvMsg.userCommandType) {
 	case OPCON_USER_COMMAND_NO_COMMAND_AVAILABLE:
 		break;
@@ -221,6 +222,7 @@ void ComputerSystem::sendDisplayCommand(int planeNumber) {
 					<< "Couldn't send command to the display.";
 			exit(-1);
 		}
+		ConnectDetach(coid);
 	} else {
 		cout
 				<< "The plane requested to update the position is not found in the airspace"
@@ -283,6 +285,7 @@ void ComputerSystem::checkForFutureViolation(
 					<< "Couldn't get user request queue from operator console";
 			exit(-1);
 		}
+		ConnectDetach(coid);
 		switch (rcvMsg.userCommandType) {
 		case OPCON_USER_COMMAND_NO_COMMAND_AVAILABLE:
 			cout << "ComputerSystem: " << "ACK from opConsole received" << endl;

--- a/ATC/src/ComputerSystem.cpp
+++ b/ATC/src/ComputerSystem.cpp
@@ -142,7 +142,34 @@ void ComputerSystem::listen() {
 }
 
 void ComputerSystem::logSystem() {
-	ofstream logfile;
+	this->airspace = radar.pingAirspace();
+	size_t aircraftCount = airspace.size();
+	int *idArray = new int[aircraftCount];
+	Vec3 *positionArray = new Vec3[aircraftCount];
+	Vec3 *velocityArray = new Vec3[aircraftCount];
+	for (size_t i = 0; i < aircraftCount; i++) {
+		auto& current = airspace[i];
+		idArray[i] = current.first;
+		positionArray[i] = current.second.currentPosition;
+		velocityArray[i] = current.second.currentVelocity;
+	}
+
+	dataDisplayCommandMessage msg;
+	msg.commandType = COMMAND_GRID;
+	msg.commandBody.multiple.numberOfAircrafts = aircraftCount;
+	msg.commandBody.multiple.planeIDArray = idArray;
+	msg.commandBody.multiple.positionArray = positionArray;
+	msg.commandBody.multiple.velocityArray = velocityArray;
+
+	int coid = ConnectAttach(0, 0, displayChid, _NTO_SIDE_CHANNEL, 0);
+	if (MsgSend(coid, &msg, sizeof(msg), NULL, 0) == -1) {
+		cout << "ComputerSystem: "
+				<< "Couldn't send command to the display.";
+		exit(-1);
+	}
+	ConnectDetach(coid);
+
+	/*ofstream logfile;
 	printCurrentTime();
 	for (auto const &x : airspace) {
 		logfile.open("logfile.txt");
@@ -159,7 +186,7 @@ void ComputerSystem::logSystem() {
 	}
 	cout << endl;
 	logfile << endl;
-	logfile.close();
+	logfile.close();*/
 }
 
 void ComputerSystem::opConCheck() {

--- a/ATC/src/ComputerSystem.h
+++ b/ATC/src/ComputerSystem.h
@@ -33,7 +33,7 @@ private:
 	void run();
 	void listen();
 	void createPeriodicTasks();
-	void logSystem();
+	void logSystem(bool toFile);
 	void violationCheck();
 	void opConCheck();
 	void sendDisplayCommand(int planeNumber);

--- a/ATC/src/DataDisplay.cpp
+++ b/ATC/src/DataDisplay.cpp
@@ -113,9 +113,9 @@ void DataDisplay::receiveMessage() {
 
 std::string DataDisplay::generateGrid(multipleAircraftDisplay &airspaceInfo)
 {
-	int rowSize = 100;
-	int columnSize = 100;
-	int cellSize = 1000;
+	int rowSize = 50;
+	int columnSize = 50;
+	int cellSize = 2000;
 
 	std::string grid[rowSize][columnSize]; //grid 100000ft x 100000ft with each square being 1000ft
 	//storing into grid
@@ -136,7 +136,7 @@ std::string DataDisplay::generateGrid(multipleAircraftDisplay &airspaceInfo)
 							grid[j][k] += ",";
 						}
 						grid[j][k] +=
-								airspaceInfo.planeIDArray[i];
+								std::to_string(airspaceInfo.planeIDArray[i]);
 					}
 				}
 			}

--- a/ATC/src/DataDisplay.cpp
+++ b/ATC/src/DataDisplay.cpp
@@ -85,13 +85,14 @@ void DataDisplay::receiveMessage() {
 		}
 		case COMMAND_GRID: //ignoring z-axis, doing x and y (top-view)
 		{
+			// The sender deletes the arrays allocated for grid printing once we reply, so we need them to stay valid until then.
+			std::cout << generateGrid(msg.commandBody.multiple);
 			MsgReply(rcvid, EOK, NULL, 0);
-			std::cout << generateGrid(msg.commandBody.multiple) << std::endl;
 			break;
 		}
 		case COMMAND_LOG: {
-			MsgReply(rcvid, EOK, NULL, 0);
 			std::string grid = generateGrid(msg.commandBody.multiple);
+			MsgReply(rcvid, EOK, NULL, 0);
 			if (fd != -1) {
 				char *buffer = new char[grid.length() + 1];
 				strncpy(buffer, grid.c_str(), grid.length() + 1);

--- a/ATC/src/DataDisplay.cpp
+++ b/ATC/src/DataDisplay.cpp
@@ -15,8 +15,8 @@
 #include <sstream>
 #include "commandCodes.h"
 
-DataDisplay::DataDisplay()
-	: chid(-1), fd(-1){
+DataDisplay::DataDisplay() :
+		chid(-1), fd(-1) {
 }
 
 int DataDisplay::getChid() const {
@@ -31,7 +31,7 @@ void DataDisplay::run() {
 
 	// Open log file
 	fd = creat("/data/home/qnxuser/airspacelog.txt",
-				S_IRUSR | S_IWUSR | S_IXUSR);
+	S_IRUSR | S_IWUSR | S_IXUSR);
 	if (fd == -1) {
 		std::cout << "DataDisplay: " << "Failed to open logfile. Errno is "
 				<< errno << std::endl;
@@ -41,7 +41,7 @@ void DataDisplay::run() {
 
 	// Close log file
 	if (fd != -1) {
-			close(fd);
+		close(fd);
 	}
 }
 
@@ -89,18 +89,19 @@ void DataDisplay::receiveMessage() {
 			std::cout << generateGrid(msg.commandBody.multiple) << std::endl;
 			break;
 		}
-		case COMMAND_LOG:
-		{
+		case COMMAND_LOG: {
 			MsgReply(rcvid, EOK, NULL, 0);
 			std::string grid = generateGrid(msg.commandBody.multiple);
 			if (fd != -1) {
-				char* buffer = new char[grid.length() + 1];
+				char *buffer = new char[grid.length() + 1];
 				strncpy(buffer, grid.c_str(), grid.length() + 1);
 				write(fd, buffer, grid.length() + 1);
 				write(fd, "\n", 1);
 				delete[] buffer;
 			} else {
-				std::cout << "DataDisplay: Received a log command but the log file is not opened." << std::endl;
+				std::cout
+						<< "DataDisplay: Received a log command but the log file is not opened."
+						<< std::endl;
 			}
 			break;
 		}
@@ -111,32 +112,27 @@ void DataDisplay::receiveMessage() {
 	}
 }
 
-std::string DataDisplay::generateGrid(multipleAircraftDisplay &airspaceInfo)
-{
+std::string DataDisplay::generateGrid(multipleAircraftDisplay &airspaceInfo) {
 	constexpr int rowSize = 50;
 	constexpr int columnSize = 50;
 	constexpr int cellSize = 2000;
 
 	std::string grid[rowSize][columnSize]; //grid 100000ft x 100000ft with each square being 1000ft
 	//storing into grid
-	for (size_t i = 0; i < airspaceInfo.numberOfAircrafts;
-			i++) {
+	for (size_t i = 0; i < airspaceInfo.numberOfAircrafts; i++) {
 		for (int j = 0; j < rowSize; j++) {
-			if (airspaceInfo.positionArray[i].y
-					>= (cellSize * j)
-					&& airspaceInfo.positionArray[i].y
-							< (cellSize * (j + 1))) { //checking y
+			if (airspaceInfo.positionArray[i].y >= (cellSize * j)
+					&& airspaceInfo.positionArray[i].y < (cellSize * (j + 1))) { //checking y
 				for (int k = 0; k < columnSize; k++) {
 					//only for x
-					if (airspaceInfo.positionArray[i].x
-							>= (cellSize * k)
+					if (airspaceInfo.positionArray[i].x >= (cellSize * k)
 							&& airspaceInfo.positionArray[i].x
 									< (cellSize * (k + 1))) { // if plane in row i is between 0 and 20 not included, add to string
 						if (grid[j][k] != "") {
 							grid[j][k] += ",";
 						}
-						grid[j][k] +=
-								std::to_string(airspaceInfo.planeIDArray[i]);
+						grid[j][k] += std::to_string(
+								airspaceInfo.planeIDArray[i]);
 					}
 				}
 			}

--- a/ATC/src/DataDisplay.cpp
+++ b/ATC/src/DataDisplay.cpp
@@ -113,9 +113,9 @@ void DataDisplay::receiveMessage() {
 
 std::string DataDisplay::generateGrid(multipleAircraftDisplay &airspaceInfo)
 {
-	int rowSize = 50;
-	int columnSize = 50;
-	int cellSize = 2000;
+	constexpr int rowSize = 50;
+	constexpr int columnSize = 50;
+	constexpr int cellSize = 2000;
 
 	std::string grid[rowSize][columnSize]; //grid 100000ft x 100000ft with each square being 1000ft
 	//storing into grid

--- a/ATC/src/DataDisplay.cpp
+++ b/ATC/src/DataDisplay.cpp
@@ -154,6 +154,7 @@ std::string DataDisplay::generateGrid(multipleAircraftDisplay &airspaceInfo)
 			}
 		}
 	}
+	output << std::endl;
 	return output.str();
 }
 

--- a/ATC/src/DataDisplay.h
+++ b/ATC/src/DataDisplay.h
@@ -8,6 +8,7 @@
 #ifndef SRC_DATADISPLAY_H_
 #define SRC_DATADISPLAY_H_
 
+#include <string>
 #include "Plane.h"
 
 //for one aircraft
@@ -40,11 +41,12 @@ class DataDisplay {
 private:
 	void run();
 	void receiveMessage();
+	std::string generateGrid(multipleAircraftDisplay &airspaceInfo);
 
 	int chid;
+	int fd;
 public:
 	DataDisplay();
-	virtual ~DataDisplay();
 
 	int getChid() const;
 	static void* start(void *context);

--- a/ATC/src/OperatorConsole.cpp
+++ b/ATC/src/OperatorConsole.cpp
@@ -103,7 +103,7 @@ void* OperatorConsole::cinRead(void *param) {
 	std::atomic_bool *stop = (std::atomic_bool*) param;
 
 	int fd = creat("/data/home/qnxuser/commandlog.txt",
-			S_IRUSR | S_IWUSR | S_IXUSR);
+	S_IRUSR | S_IWUSR | S_IXUSR);
 	if (fd == -1) {
 		std::cout << "OpConsole: " << "Failed to open logfile. Errno is "
 				<< errno << std::endl;

--- a/ATC/src/Plane.h
+++ b/ATC/src/Plane.h
@@ -37,10 +37,10 @@ typedef struct Vec3 {
 	Vec3 scalarMultiplication(int scalarMultiplier) {
 		return {x*scalarMultiplier, y*scalarMultiplier, z*scalarMultiplier};
 	}
-	bool operator==(const Vec3& rhs) {
+	bool operator==(const Vec3 &rhs) {
 		return x == rhs.x && y == rhs.y && z == rhs.z;
 	}
-	bool operator!=(const Vec3& rhs) {
+	bool operator!=(const Vec3 &rhs) {
 		return x != rhs.x && y != rhs.y && z != rhs.z;
 	}
 	int x;

--- a/ATC/src/Radar.cpp
+++ b/ATC/src/Radar.cpp
@@ -40,6 +40,8 @@ PlanePositionResponse Radar::pingPlane(Plane &p) {
 	msg.command = COMMAND_RADAR_PING;
 	PlanePositionResponse res;
 	MsgSend(coid, &msg, sizeof(msg), &res, sizeof(res));
+
+	ConnectDetach(coid);
 	return res;
 }
 

--- a/ATC/src/Radar.h
+++ b/ATC/src/Radar.h
@@ -1,4 +1,3 @@
-
 #ifndef SRC_RADAR_H_
 #define SRC_RADAR_H_
 

--- a/ATC/src/commandCodes.h
+++ b/ATC/src/commandCodes.h
@@ -41,6 +41,8 @@
 #define COMMAND_WARNING 1113
 // Incoming command to display the grid view of the airspace.
 #define COMMAND_GRID 1114
+// Incoming command to log the grid view of the airspace.
+#define COMMAND_LOG 1115
 
 /*
  * OperatorConsole command codes

--- a/ATC/src/commandCodes.h
+++ b/ATC/src/commandCodes.h
@@ -17,10 +17,12 @@
 // To create timers for periodic tasks we need to know the amount
 // Timer code to fire to perform violation checks
 #define AIRSPACE_VIOLATION_CONSTRAINT_TIMER 11
-// Timer code to fire to update logfile with airspace state
-#define LOG_AIRSPACE_TIMER 12
+// Timer code to fire to print airspace state to console
+#define LOG_AIRSPACE_TO_CONSOLE_TIMER 12
 // Timer code to fire a request to operator console for command info
 #define OPERATOR_COMMAND_CHECK_TIMER 13
+// Timer code to fire to print airspace state to log file
+#define LOG_AIRSPACE_TO_FILE_TIMER 14
 
 // Inbound command to the system to process operator request
 #define COMMAND_OPERATOR_REQUEST 111

--- a/ATC/src/constants.h
+++ b/ATC/src/constants.h
@@ -11,4 +11,4 @@
 #define TIME_RANGE_SECONDS 180
 
 //Number of periodic tasks in the computerSystem class
-#define COMPUTER_SYSTEM_NUM_PERIODIC_TASKS 3
+#define COMPUTER_SYSTEM_NUM_PERIODIC_TASKS 4


### PR DESCRIPTION
Adds periodic printing of the airspace. Adds periodic logging of the airspace to an output file. Expands and cleans up the demo function. Modifies the violation check to avoid false positives. Adds `ConnectDetach` statements to avoid leaving behind open connections (not sure if failing to do this actually causes any problems, but better safe than sorry).